### PR TITLE
Error from calling scrollToTop() on <ion-content>

### DIFF
--- a/src/directives/ion-affix.ts
+++ b/src/directives/ion-affix.ts
@@ -42,11 +42,11 @@ export class IonAffix implements AfterViewInit, OnDestroy {
         this.updateSticky(this.content.getScrollElement().scrollTop, containerTop, containerBottom, contentScrollTop, headerHeight, left, right, true);
 
         const onScroll = event => {
-            const scrollTop = event.scrollTop;
+            const scrollTop = this.content.scrollTop;
             contentScrollTop = this.content.getScrollElement().getBoundingClientRect().top;
             containerTop = this.containerElement.offsetTop;
             containerBottom = containerTop + this.containerElement.getBoundingClientRect().height;
-            this.updateSticky(scrollTop, containerTop, containerBottom, contentScrollTop, headerHeight, left, right, event.directionY === 'down');
+            this.updateSticky(scrollTop, containerTop, containerBottom, contentScrollTop, headerHeight, left, right, this.content.directionY === 'down');
         };
         this.scrollSubscriptions.push(this.content.ionScrollStart.subscribe(onScroll));
         this.scrollSubscriptions.push(this.content.ionScroll.subscribe(onScroll));


### PR DESCRIPTION
When scrollToTop is called on a ionContent, the event argument in the onScroll-listener i null, which causes an error.

My suggestion is to get scrollTop and directionY from this.content instead.

I'm using ionic-angular 3.5.3.